### PR TITLE
Upgrade depencency to ramsey/uuid 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ with the bundled [AggregateRoot](https://github.com/prooph/event-sourcing/blob/m
 
 #Used Third-Party Libraries
 
-- Uuids of the AggregateChangedEvents are generated with [rhumsaa/uuid](https://github.com/ramsey/uuid)
+- Uuids of the AggregateChangedEvents are generated with [ramsey/uuid](https://github.com/ramsey/uuid)
 - Assertions are performed by [beberlei/assert](https://github.com/beberlei/assert)
 
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "~5.5|~7.0",
-        "ramsey/uuid" : "~2.8",
+        "ramsey/uuid" : "~2.8|~3.0",
         "beberlei/assert": "~2.3",
         "prooph/common": "~3.5"
     },

--- a/examples/quickstart.php
+++ b/examples/quickstart.php
@@ -18,7 +18,7 @@ namespace My\Model {
 
     use Prooph\EventSourcing\AggregateChanged;
     use Prooph\EventSourcing\AggregateRoot;
-    use Rhumsaa\Uuid\Uuid;
+    use Ramsey\Uuid\Uuid;
 
     class User extends AggregateRoot
     {
@@ -197,7 +197,7 @@ namespace My\Infrastructure {
     use Prooph\EventStore\Aggregate\AggregateRepository;
     use Prooph\EventStore\Aggregate\AggregateType;
     use Prooph\EventStore\EventStore;
-    use Rhumsaa\Uuid\Uuid;
+    use Ramsey\Uuid\Uuid;
 
     /**
      * Class UserRepositoryImpl extends Prooph\EventStore\Aggregate\AggregateRepository and implements My\Model\UserRepository

--- a/tests/AggregateChangedTest.php
+++ b/tests/AggregateChangedTest.php
@@ -28,7 +28,7 @@ class AggregateChangedTest extends TestCase
     {
         $event = AggregateChanged::occur('1', []);
 
-        $this->assertInstanceOf('Rhumsaa\Uuid\Uuid', $event->uuid());
+        $this->assertInstanceOf('Ramsey\Uuid\Uuid', $event->uuid());
     }
 
     /**

--- a/tests/Mock/BrokenUser.php
+++ b/tests/Mock/BrokenUser.php
@@ -13,7 +13,7 @@ namespace ProophTest\EventSourcing\Mock;
 
 use Prooph\EventSourcing\AggregateChanged;
 use Prooph\EventSourcing\AggregateRoot;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Class BrokenUser

--- a/tests/Mock/User.php
+++ b/tests/Mock/User.php
@@ -12,7 +12,7 @@
 namespace ProophTest\EventSourcing\Mock;
 
 use Prooph\EventSourcing\AggregateRoot;
-use Rhumsaa\Uuid\Uuid;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Class User


### PR DESCRIPTION
This change bases the existing code on the 3.x version of ramsey/uuid (previously called rhumsaa/uuid) in order to avoid conflicts with third-party libraries which require version 3.0 or higher.