### PR TITLE
moves ramsey/uuid dependency to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     ],
     "require": {
         "php": "~5.5|~7.0",
-        "ramsey/uuid" : "~2.8",
         "beberlei/assert": "~2.3",
         "prooph/common": "~3.5"
     },
@@ -30,7 +29,8 @@
         "phpunit/phpunit": "~4.8",
         "prooph/event-store" : "dev-develop",
         "fabpot/php-cs-fixer": "1.7.*",
-        "satooshi/php-coveralls": "^1.0"
+        "satooshi/php-coveralls": "^1.0",
+        "ramsey/uuid": "~2.8"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The dependency "ramsey/uuid" is only used in tests and example, so it should be moved to require-dev.