### PR TITLE
[WIP] Benchmark for class name determination

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,5 +1,6 @@
 <?php
 $finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->in('benchmarks')
     ->in('examples')
     ->in('src')
     ->in('tests');

--- a/benchmarks/DetermineClassNameBench.php
+++ b/benchmarks/DetermineClassNameBench.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file is part of the prooph/event-sourcing.
+ * (c) 2014-2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2016 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophBench;
+
+use Prooph\EventSourcing\AggregateChanged;
+
+/**
+ * @author Eric Braun <eb@oqq.be>
+ *
+ * @BeforeMethods({"initDomainEvent"})
+ * @Revs(10000)
+ * @Iterations(10)
+ */
+final class DetermineClassNameBench
+{
+    /** @var AggregateChanged */
+    private $event;
+
+    public function initDomainEvent(): void
+    {
+        $this->event = AggregateChanged::occur('1');
+    }
+
+    public function benchReflection(): void
+    {
+        (new \ReflectionClass($this->event))->getShortName();
+    }
+
+    public function benchArraySlice(): void
+    {
+        implode(array_slice(explode('\\', get_class($this->event)), -1));
+    }
+
+    public function benchArrayPop(): void
+    {
+        $path = explode('\\', get_class($this->event));
+        array_pop($path);
+    }
+
+    public function benchSubstring(): void
+    {
+        $class = get_class($this->event);
+        substr($class, strrpos($class, '\\') + 1);
+    }
+
+    public function benchEnd(): void
+    {
+        $path = explode('\\', get_class($this->event));
+        end($path);
+    }
+
+    public function benchBasename(): void
+    {
+        basename(str_replace('\\', '/', get_class($this)));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "friendsofphp/php-cs-fixer": "^1.12.2",
         "phpspec/prophecy": "dev-patch-1 as 1.6.1",
         "satooshi/php-coveralls": "^1.0",
-        "malukenho/docheader": "^0.1.4"
+        "malukenho/docheader": "^0.1.4",
+        "phpbench/phpbench": "^0.12.2"
     },
     "autoload": {
         "psr-4": {

--- a/phpbench.json.dist
+++ b/phpbench.json.dist
@@ -1,0 +1,4 @@
+{
+    "bootstrap": "vendor/autoload.php",
+    "path": "benchmarks"
+}


### PR DESCRIPTION
This PR provides a benchmark for the `AggregateRoot::determineEventHandlerMethodFor()` method.
Without challenging the current implementation, this benchmark could has affects in future implementations, since we are currently not using the best performant way.
