### PR TITLE
remove determine handler method from aggregate root

### DIFF
--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -92,26 +92,6 @@ abstract class AggregateRoot
 
     /**
      * Apply given event
-     *
-     * @throws \RuntimeException
      */
-    protected function apply(AggregateChanged $e): void
-    {
-        $handler = $this->determineEventHandlerMethodFor($e);
-
-        if (! method_exists($this, $handler)) {
-            throw new \RuntimeException(sprintf(
-                'Missing event handler method %s for aggregate root %s',
-                $handler,
-                get_class($this)
-            ));
-        }
-
-        $this->{$handler}($e);
-    }
-
-    protected function determineEventHandlerMethodFor(AggregateChanged $e): string
-    {
-        return 'when' . implode(array_slice(explode('\\', get_class($e)), -1));
-    }
+    abstract protected function apply(AggregateChanged $e): void;
 }

--- a/src/EventStoreIntegration/AggregateRootDecorator.php
+++ b/src/EventStoreIntegration/AggregateRootDecorator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Prooph\EventSourcing\EventStoreIntegration;
 
 use Iterator;
+use Prooph\EventSourcing\AggregateChanged;
 use Prooph\EventSourcing\AggregateRoot;
 
 class AggregateRootDecorator extends AggregateRoot
@@ -67,5 +68,9 @@ class AggregateRootDecorator extends AggregateRoot
     protected function aggregateId(): string
     {
         throw new \BadMethodCallException('The AggregateRootDecorator does not have an id');
+    }
+
+    protected function apply(AggregateChanged $e): void
+    {
     }
 }

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -15,6 +15,7 @@ namespace ProophTest\EventSourcing;
 use Prooph\EventSourcing\EventStoreIntegration\AggregateRootDecorator;
 use ProophTest\EventSourcing\Mock\BrokenUser;
 use ProophTest\EventSourcing\Mock\User;
+use ProophTest\EventSourcing\Mock\UserCreated;
 
 class AggregateRootTest extends TestCase
 {
@@ -66,7 +67,7 @@ class AggregateRootTest extends TestCase
     public function it_throws_exception_when_no_handler_on_aggregate()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Missing event handler method whenUserCreated for aggregate root ProophTest\EventSourcing\Mock\BrokenUser');
+        $this->expectExceptionMessage('Unknown event "' . UserCreated::class . '" applied to user aggregate');
 
         $brokenUser = BrokenUser::nameNew('John');
 

--- a/tests/Mock/BrokenUser.php
+++ b/tests/Mock/BrokenUser.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace ProophTest\EventSourcing\Mock;
 
+use Prooph\EventSourcing\AggregateChanged;
 use Prooph\EventSourcing\AggregateRoot;
 use Ramsey\Uuid\Uuid;
 
@@ -67,4 +68,19 @@ class BrokenUser extends AggregateRoot
     {
         return $this->id();
     }
+
+    protected function apply(AggregateChanged $e): void
+    {
+        switch (get_class($e)) {
+            default:
+                throw new \RuntimeException(
+                    sprintf(
+                        'Unknown event "%s" applied to user aggregate',
+                        $e->messageName()
+                    )
+                );
+        }
+    }
+
+
 }

--- a/tests/Mock/BrokenUser.php
+++ b/tests/Mock/BrokenUser.php
@@ -81,6 +81,4 @@ class BrokenUser extends AggregateRoot
                 );
         }
     }
-
-
 }

--- a/tests/Mock/User.php
+++ b/tests/Mock/User.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace ProophTest\EventSourcing\Mock;
 
+use Prooph\EventSourcing\AggregateChanged;
 use Prooph\EventSourcing\AggregateRoot;
 use Ramsey\Uuid\Uuid;
 
@@ -57,17 +58,6 @@ class User extends AggregateRoot
         return $this->name;
     }
 
-    protected function whenUserCreated(UserCreated $event): void
-    {
-        $this->id = $event->userId();
-        $this->name = $event->name();
-    }
-
-    protected function whenUsernameChanged(UserNameChanged $event): void
-    {
-        $this->name = $event->newUsername();
-    }
-
     /**
      * @return \Prooph\EventSourcing\AggregateChanged[]
      */
@@ -82,5 +72,25 @@ class User extends AggregateRoot
     protected function aggregateId(): string
     {
         return $this->id();
+    }
+
+    protected function apply(AggregateChanged $e): void
+    {
+        switch (get_class($e)) {
+            case UserCreated::class:
+                $this->id = $e->userId();
+                $this->name = $e->name();
+                break;
+            case UserNameChanged::class:
+                $this->name = $e->newUsername();
+                break;
+            default:
+                throw new \RuntimeException(
+                    sprintf(
+                        'Unknown event "%s" applied to user aggregate',
+                        $e->messageName()
+                    )
+                );
+        }
     }
 }


### PR DESCRIPTION
This will lead to better performance. If the old behaviour is wanted, this can also be implemented in userland code.