### PR TITLE
Bump snapshot store dependency to stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "psr/container": "^1.0",
         "sandrokeil/interop-config": "^2.0.1",
         "phpunit/phpunit": "^6.0",
-        "prooph/snapshot-store": "1.0.x-dev",
+        "prooph/snapshot-store": "^1.2.0",
         "prooph/php-cs-fixer-config": "^0.1.1",
         "phpspec/prophecy": "^1.7",
         "satooshi/php-coveralls": "^1.0",


### PR DESCRIPTION
`prooph/snapshot-store` `1.0.x-dev` no longer can be resolved, bump it to stable