### PR TITLE
Extract aggregate root into traits to make it easier to avoid domain extending infrastructure

### DIFF
--- a/docs/inheritance.md
+++ b/docs/inheritance.md
@@ -127,3 +127,29 @@ then you can also just change the `aggregate_translator` key in your config to p
 and register the `UserAggregateTranslator` in your container.
 
 see also: http://www.sasaprolic.com/2016/02/inheritance-with-aggregate-roots-in.html
+
+## Alternative to AggregateRoot inheritance
+
+Abstract `Prooph\EventSourcing\AggregateRoot` class provides a solid basis for
+your aggregate roots, however, it is not mandatory. Two traits,
+`Prooph\EventSourcing\Aggregate\EventProducerTrait` and
+`Prooph\EventSourcing\Aggregate\EventSourcedTrait`, together provide exactly
+the same functionality.
+
+- `EventProducerTrait` is responsible for event producing side of Event
+  Sourcing and might be used independently of `EventSourcedTrait` when you are
+  not ready to start with full event sourcing but still want to get the benefit
+  of design validation and audit trail provided by Event Sourcing. Forcing all
+  changes to be applied internally via event sourcing will ensure events data
+  consistency with the state and will make it easier to switch to full event
+  sourcing later on.
+
+- `EventSourcedTrait` is responsible for restoring state from event stream, it
+  should be used together with `EventProducerTrait` as normally you will not be
+  applying events not produced by that aggregate root.
+
+Default aggregate translator uses `AggregateRootDecorator` to access protected
+methods of `Prooph\EventSourcing\AggregateRoot` descendants, you will need to
+switch to
+`Prooph\EventSourcing\EventStoreIntegration\ClosureAggregateTranslator` for
+aggregate roots using traits.

--- a/src/Aggregate/EventProducerTrait.php
+++ b/src/Aggregate/EventProducerTrait.php
@@ -56,6 +56,8 @@ trait EventProducerTrait
         $this->apply($event);
     }
 
+    abstract protected function aggregateId(): string;
+
     /**
      * Apply given event
      */

--- a/src/Aggregate/EventProducerTrait.php
+++ b/src/Aggregate/EventProducerTrait.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * This file is part of the prooph/event-sourcing.
+ * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventSourcing\Aggregate;
+
+use Prooph\EventSourcing\AggregateChanged;
+
+trait EventProducerTrait
+{
+    /**
+     * Current version
+     *
+     * @var int
+     */
+    protected $version = 0;
+
+    /**
+     * List of events that are not committed to the EventStore
+     *
+     * @var AggregateChanged[]
+     */
+    protected $recordedEvents = [];
+
+    /**
+     * Get pending events and reset stack
+     *
+     * @return AggregateChanged[]
+     */
+    protected function popRecordedEvents(): array
+    {
+        $pendingEvents = $this->recordedEvents;
+
+        $this->recordedEvents = [];
+
+        return $pendingEvents;
+    }
+
+    /**
+     * Record an aggregate changed event
+     */
+    protected function recordThat(AggregateChanged $event): void
+    {
+        $this->version += 1;
+
+        $this->recordedEvents[] = $event->withVersion($this->version);
+
+        $this->apply($event);
+    }
+
+    /**
+     * Apply given event
+     */
+    abstract protected function apply(AggregateChanged $event): void;
+}

--- a/src/Aggregate/EventSourcedTrait.php
+++ b/src/Aggregate/EventSourcedTrait.php
@@ -51,6 +51,8 @@ trait EventSourcedTrait
         }
     }
 
+    abstract protected function aggregateId(): string;
+
     /**
      * Apply given event
      */

--- a/src/Aggregate/EventSourcedTrait.php
+++ b/src/Aggregate/EventSourcedTrait.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of the prooph/event-sourcing.
+ * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventSourcing\Aggregate;
+
+use Iterator;
+use Prooph\EventSourcing\AggregateChanged;
+use RuntimeException;
+
+trait EventSourcedTrait
+{
+    /**
+     * Current version
+     *
+     * @var int
+     */
+    protected $version = 0;
+
+    /**
+     * @throws RuntimeException
+     */
+    protected static function reconstituteFromHistory(Iterator $historyEvents): self
+    {
+        $instance = new static();
+        $instance->replay($historyEvents);
+
+        return $instance;
+    }
+
+    /**
+     * Replay past events
+     *
+     * @throws RuntimeException
+     */
+    protected function replay(Iterator $historyEvents): void
+    {
+        foreach ($historyEvents as $pastEvent) {
+            /** @var AggregateChanged $pastEvent */
+            $this->version = $pastEvent->version();
+
+            $this->apply($pastEvent);
+        }
+    }
+
+    /**
+     * Apply given event
+     */
+    abstract protected function apply(AggregateChanged $event): void;
+}

--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -27,6 +27,4 @@ abstract class AggregateRoot
     protected function __construct()
     {
     }
-
-    abstract protected function aggregateId(): string;
 }

--- a/src/EventStoreIntegration/ClosureAggregateTranslator.php
+++ b/src/EventStoreIntegration/ClosureAggregateTranslator.php
@@ -14,7 +14,9 @@ namespace Prooph\EventSourcing\EventStoreIntegration;
 
 use Iterator;
 use Prooph\Common\Messaging\Message;
+use Prooph\EventSourcing\Aggregate\AggregateTranslator as EventStoreAggregateTranslator;
 use Prooph\EventSourcing\Aggregate\AggregateType;
+use RuntimeException;
 
 final class ClosureAggregateTranslator implements EventStoreAggregateTranslator
 {

--- a/src/EventStoreIntegration/ClosureAggregateTranslator.php
+++ b/src/EventStoreIntegration/ClosureAggregateTranslator.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * This file is part of the prooph/event-sourcing.
+ * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventSourcing\EventStoreIntegration;
+
+use Iterator;
+use Prooph\Common\Messaging\Message;
+use Prooph\EventSourcing\Aggregate\AggregateType;
+
+final class ClosureAggregateTranslator implements EventStoreAggregateTranslator
+{
+    protected $aggregateIdExtractor;
+    protected $aggregateReconstructor;
+    protected $pendingEventsExtractor;
+    protected $replayStreamEvents;
+    protected $versionExtractor;
+
+    /**
+     * @param object $eventSourcedAggregateRoot
+     *
+     * @return int
+     */
+    public function extractAggregateVersion($eventSourcedAggregateRoot): int
+    {
+        if (null === $this->versionExtractor) {
+            $this->versionExtractor = function (): int {
+                return $this->version;
+            };
+        }
+
+        return $this->versionExtractor->call($eventSourcedAggregateRoot);
+    }
+
+    /**
+     * @param object $anEventSourcedAggregateRoot
+     *
+     * @return string
+     */
+    public function extractAggregateId($anEventSourcedAggregateRoot): string
+    {
+        if (null === $this->aggregateIdExtractor) {
+            $this->aggregateIdExtractor = function (): string {
+                return $this->aggregateId();
+            };
+        }
+
+        return $this->aggregateIdExtractor->call($anEventSourcedAggregateRoot);
+    }
+
+    /**
+     * @param AggregateType $aggregateType
+     * @param Iterator $historyEvents
+     *
+     * @return object reconstructed AggregateRoot
+     */
+    public function reconstituteAggregateFromHistory(AggregateType $aggregateType, Iterator $historyEvents)
+    {
+        if (null === $this->aggregateReconstructor) {
+            $this->aggregateReconstructor = function ($historyEvents) {
+                return static::reconstituteFromHistory($historyEvents);
+            };
+        }
+
+        $arClass = $aggregateType->toString();
+
+        if (! class_exists($arClass)) {
+            throw new RuntimeException(
+                sprintf('Aggregate root class %s cannot be found', $arClass)
+            );
+        }
+
+        return ($this->aggregateReconstructor->bindTo(null, $arClass))($historyEvents);
+    }
+
+    /**
+     * @param object $anEventSourcedAggregateRoot
+     *
+     * @return Message[]
+     */
+    public function extractPendingStreamEvents($anEventSourcedAggregateRoot): array
+    {
+        if (null === $this->pendingEventsExtractor) {
+            $this->pendingEventsExtractor = function (): array {
+                return $this->popRecordedEvents();
+            };
+        }
+
+        return $this->pendingEventsExtractor->call($anEventSourcedAggregateRoot);
+    }
+
+    /**
+     * @param object $anEventSourcedAggregateRoot
+     * @param Iterator $events
+     *
+     * @return void
+     */
+    public function replayStreamEvents($anEventSourcedAggregateRoot, Iterator $events): void
+    {
+        if (null === $this->replayStreamEvents) {
+            $this->replayStreamEvents = function ($events): void {
+                $this->replay($events);
+            };
+        }
+        $this->replayStreamEvents->call($anEventSourcedAggregateRoot, $events);
+    }
+}

--- a/tests/EventStoreIntegration/ClosureAggregateTranslatorTest.php
+++ b/tests/EventStoreIntegration/ClosureAggregateTranslatorTest.php
@@ -17,16 +17,16 @@ use PHPUnit\Framework\TestCase;
 use Prooph\Common\Event\ProophActionEventEmitter;
 use Prooph\EventSourcing\Aggregate\AggregateRepository;
 use Prooph\EventSourcing\Aggregate\AggregateType;
-use Prooph\EventSourcing\EventStoreIntegration\AggregateRootDecorator;
-use Prooph\EventSourcing\EventStoreIntegration\AggregateTranslator;
+use Prooph\EventSourcing\EventStoreIntegration\ClosureAggregateTranslator as AggregateTranslator;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\InMemoryEventStore;
 use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
 use ProophTest\EventSourcing\Mock\User;
 use ProophTest\EventSourcing\Mock\UserNameChanged;
+use RuntimeException;
 
-class AggregateTranslatorTest extends TestCase
+class ClosureAggregateTranslatorTest extends TestCase
 {
     /**
      * @var InMemoryEventStore
@@ -115,14 +115,16 @@ class AggregateTranslatorTest extends TestCase
     /**
      * @test
      */
-    public function it_can_use_custom_aggregate_root_decorator()
+    public function it_throws_exception_when_reconstitute_from_history_with_invalid_class()
     {
-        $mock = $this->createMock(AggregateRootDecorator::class);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Aggregate root class UnknownClass cannot be found');
 
         $translator = new AggregateTranslator();
-        $translator->setAggregateRootDecorator($mock);
-
-        $this->assertSame($mock, $translator->getAggregateRootDecorator());
+        $translator->reconstituteAggregateFromHistory(
+            AggregateType::fromString('UnknownClass'),
+            new ArrayIterator([])
+        );
     }
 
     protected function resetRepository()


### PR DESCRIPTION
I strongly oppose the idea of my entities extending anything from the infrastructure.
All I need is to implement `AggregateTranslator`. While it is easy to implement in my own codebase, i believe it would be better placed directly in the `event-sourcing` package.

This PR extracts `AggregateRoot` code into two traits, EventProducerTrait and EventSourcedTrait, and introduces closure translator that can work both with `AggregateRoot` and with entities implementing same "interface". 