### PR TITLE
Add static type hint to docblock

### DIFF
--- a/src/AggregateChanged.php
+++ b/src/AggregateChanged.php
@@ -22,6 +22,9 @@ class AggregateChanged extends DomainEvent
      */
     protected $payload = [];
 
+    /**
+     * @return static
+     */
     public static function occur(string $aggregateId, array $payload = []): self
     {
         return new static($aggregateId, $payload);


### PR DESCRIPTION
Since php does not allow us to specify static as a return type, we should provide it through a docblock.
This will remove the need to explicitly type hint through a doc block in all the extending classes that use this method.