### PR TITLE
Move 'aggregateId' up

### DIFF
--- a/src/Aggregate/EventProducerTrait.php
+++ b/src/Aggregate/EventProducerTrait.php
@@ -56,8 +56,6 @@ trait EventProducerTrait
         $this->apply($event);
     }
 
-    abstract protected function aggregateId(): string;
-
     /**
      * Apply given event
      */

--- a/src/Aggregate/EventSourcedTrait.php
+++ b/src/Aggregate/EventSourcedTrait.php
@@ -51,8 +51,6 @@ trait EventSourcedTrait
         }
     }
 
-    abstract protected function aggregateId(): string;
-
     /**
      * Apply given event
      */

--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -27,4 +27,6 @@ abstract class AggregateRoot
     protected function __construct()
     {
     }
+
+    abstract protected function aggregateId(): string;
 }


### PR DESCRIPTION
This PR moves the abstract method 'aggregateId' up from traits to the abstract class, since the traits have to dependency on it at all.