### PR TITLE
Allow to add a custom event store to AggregateRepository

### DIFF
--- a/docs/interop_factories.md
+++ b/docs/interop_factories.md
@@ -96,6 +96,24 @@ You can also configure a custom stream name (default is `event_stream`):
 ]
 ```
 
+You can add your custom event store too (default is `EventStore::class`):
+```php
+[
+    'prooph' => [
+        'event_sourcing' => [
+            'aggregate_repository' => [
+                'user_repository' => [
+                    'repository_class' => MyUserRepository::class,
+                    'event_store' => MyCustomEventStore::class, // <-- Custom event store service id
+                    'aggregate_type' => MyUser::class,
+                    'aggregate_translator' => 'user_translator',
+                ],
+            ],
+        ],
+    ],
+]
+```
+
 Last but not least you can enable the so called "One-Stream-Per-Aggregate-Mode":
 ```php
 [

--- a/src/Container/Aggregate/AggregateRepositoryFactory.php
+++ b/src/Container/Aggregate/AggregateRepositoryFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Prooph\EventSourcing\Container\Aggregate;
 
 use Interop\Config\ConfigurationTrait;
+use Interop\Config\ProvidesDefaultOptions;
 use Interop\Config\RequiresConfigId;
 use Interop\Config\RequiresMandatoryOptions;
 use InvalidArgumentException;
@@ -23,7 +24,7 @@ use Prooph\EventStore\Exception\ConfigurationException;
 use Prooph\EventStore\StreamName;
 use Psr\Container\ContainerInterface;
 
-final class AggregateRepositoryFactory implements RequiresConfigId, RequiresMandatoryOptions
+final class AggregateRepositoryFactory implements RequiresConfigId, RequiresMandatoryOptions, ProvidesDefaultOptions
 {
     use ConfigurationTrait;
 
@@ -81,13 +82,7 @@ final class AggregateRepositoryFactory implements RequiresConfigId, RequiresMand
             throw ConfigurationException::configurationError(sprintf('Repository class %s must be a sub class of %s', $repositoryClass, AggregateRepository::class));
         }
 
-        $eventStoreClass = $config['event_store_class'] ?? EventStore::class;
-
-        $eventStore = $container->get($eventStoreClass);
-
-        if (! $eventStore instanceof EventStore) {
-            throw ConfigurationException::configurationError(sprintf('Event store class %s must be of type %s', $eventStoreClass, EventStore::class));
-        }
+        $eventStore = $container->get($config['event_store']);
 
         if (is_array($config['aggregate_type'])) {
             $aggregateType = AggregateType::fromMapping($config['aggregate_type']);
@@ -124,6 +119,18 @@ final class AggregateRepositoryFactory implements RequiresConfigId, RequiresMand
             'repository_class',
             'aggregate_type',
             'aggregate_translator',
+        ];
+    }
+
+    /**
+     * Returns a list of default options, which are merged in \Interop\Config\RequiresConfig::options()
+     *
+     * @return iterable List with default options and values, can be nested
+     */
+    public function defaultOptions() : iterable
+    {
+        return [
+            'event_store' => EventStore::class,
         ];
     }
 }

--- a/src/Container/Aggregate/AggregateRepositoryFactory.php
+++ b/src/Container/Aggregate/AggregateRepositoryFactory.php
@@ -81,7 +81,13 @@ final class AggregateRepositoryFactory implements RequiresConfigId, RequiresMand
             throw ConfigurationException::configurationError(sprintf('Repository class %s must be a sub class of %s', $repositoryClass, AggregateRepository::class));
         }
 
-        $eventStore = $container->get(EventStore::class);
+        $eventStoreClass = $config['event_store_class'] ?? EventStore::class;
+
+        $eventStore = $container->get($eventStoreClass);
+
+        if (! $eventStore instanceof EventStore) {
+            throw ConfigurationException::configurationError(sprintf('Event store class %s must be of type %s', $eventStoreClass, EventStore::class));
+        }
 
         if (is_array($config['aggregate_type'])) {
             $aggregateType = AggregateType::fromMapping($config['aggregate_type']);

--- a/src/Container/Aggregate/AggregateRepositoryFactory.php
+++ b/src/Container/Aggregate/AggregateRepositoryFactory.php
@@ -127,7 +127,7 @@ final class AggregateRepositoryFactory implements RequiresConfigId, RequiresMand
      *
      * @return iterable List with default options and values, can be nested
      */
-    public function defaultOptions() : iterable
+    public function defaultOptions(): iterable
     {
         return [
             'event_store' => EventStore::class,

--- a/tests/Container/Aggregate/AggregateRepositoryFactoryTest.php
+++ b/tests/Container/Aggregate/AggregateRepositoryFactoryTest.php
@@ -68,7 +68,7 @@ class AggregateRepositoryFactoryTest extends ActionEventEmitterEventStoreTestCas
                     'aggregate_repository' => [
                         'repository_mock' => [
                             'repository_class' => RepositoryMock::class,
-                            'event_store_class' => EventStoreMock::class,
+                            'event_store' => EventStoreMock::class,
                             'aggregate_type' => User::class,
                             'aggregate_translator' => 'user_translator',
                         ],
@@ -156,7 +156,7 @@ class AggregateRepositoryFactoryTest extends ActionEventEmitterEventStoreTestCas
      */
     public function it_throws_exception_when_invalid_event_store_class_given(): void
     {
-        $this->expectException(ConfigurationException::class);
+        $this->expectException(\TypeError::class);
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->has('config')->willReturn(true);
@@ -166,7 +166,7 @@ class AggregateRepositoryFactoryTest extends ActionEventEmitterEventStoreTestCas
                     'aggregate_repository' => [
                         'repository_mock' => [
                             'repository_class' => RepositoryMock::class,
-                            'event_store_class' => 'stdClass',
+                            'event_store' => 'stdClass',
                             'aggregate_type' => User::class,
                             'aggregate_translator' => 'user_translator',
                         ],

--- a/tests/Container/Aggregate/AggregateRepositoryFactoryTest.php
+++ b/tests/Container/Aggregate/AggregateRepositoryFactoryTest.php
@@ -17,6 +17,7 @@ use Prooph\EventSourcing\Aggregate\AggregateTranslator;
 use Prooph\EventSourcing\Container\Aggregate\AggregateRepositoryFactory;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Exception\ConfigurationException;
+use ProophTest\EventSourcing\Mock\EventStoreMock;
 use ProophTest\EventSourcing\Mock\RepositoryMock;
 use ProophTest\EventStore\ActionEventEmitterEventStoreTestCase;
 use ProophTest\EventStore\Mock\User;
@@ -45,6 +46,37 @@ class AggregateRepositoryFactoryTest extends ActionEventEmitterEventStoreTestCas
             ],
         ]);
         $container->get(EventStore::class)->willReturn($this->eventStore);
+
+        $userTranslator = $this->prophesize(AggregateTranslator::class);
+
+        $container->get('user_translator')->willReturn($userTranslator->reveal());
+
+        $factory = [AggregateRepositoryFactory::class, 'repository_mock'];
+        self::assertInstanceOf(RepositoryMock::class, $factory($container->reveal()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_an_aggregate_from_static_call_with_custom_event_store(): void
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn([
+            'prooph' => [
+                'event_sourcing' => [
+                    'aggregate_repository' => [
+                        'repository_mock' => [
+                            'repository_class' => RepositoryMock::class,
+                            'event_store_class' => EventStoreMock::class,
+                            'aggregate_type' => User::class,
+                            'aggregate_translator' => 'user_translator',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $container->get(EventStoreMock::class)->willReturn($this->eventStore);
 
         $userTranslator = $this->prophesize(AggregateTranslator::class);
 
@@ -117,6 +149,39 @@ class AggregateRepositoryFactoryTest extends ActionEventEmitterEventStoreTestCas
 
         $factory = new AggregateRepositoryFactory('repository_mock');
         $factory->__invoke($container->reveal());
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_invalid_event_store_class_given(): void
+    {
+        $this->expectException(ConfigurationException::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn([
+            'prooph' => [
+                'event_sourcing' => [
+                    'aggregate_repository' => [
+                        'repository_mock' => [
+                            'repository_class' => RepositoryMock::class,
+                            'event_store_class' => 'stdClass',
+                            'aggregate_type' => User::class,
+                            'aggregate_translator' => 'user_translator',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $container->get('stdClass')->willReturn('stdClass');
+
+        $userTranslator = $this->prophesize(AggregateTranslator::class);
+
+        $container->get('user_translator')->willReturn($userTranslator->reveal());
+
+        $factory = [AggregateRepositoryFactory::class, 'repository_mock'];
+        self::assertInstanceOf(RepositoryMock::class, $factory($container->reveal()));
     }
 
     /**

--- a/tests/Mock/EventStoreMock.php
+++ b/tests/Mock/EventStoreMock.php
@@ -20,25 +20,20 @@ use Prooph\EventStore\StreamName;
 
 final class EventStoreMock implements EventStore
 {
-
     public function updateStreamMetadata(StreamName $streamName, array $newMetadata): void
     {
-
     }
 
     public function create(Stream $stream): void
     {
-
     }
 
     public function appendTo(StreamName $streamName, Iterator $streamEvents): void
     {
-
     }
 
     public function delete(StreamName $streamName): void
     {
-
     }
 
     public function fetchStreamMetadata(StreamName $streamName): array

--- a/tests/Mock/EventStoreMock.php
+++ b/tests/Mock/EventStoreMock.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * This file is part of the prooph/event-sourcing.
+ * (c) 2014-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventSourcing\Mock;
+
+use Iterator;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Metadata\MetadataMatcher;
+use Prooph\EventStore\Stream;
+use Prooph\EventStore\StreamName;
+
+final class EventStoreMock implements EventStore
+{
+
+    public function updateStreamMetadata(StreamName $streamName, array $newMetadata): void
+    {
+
+    }
+
+    public function create(Stream $stream): void
+    {
+
+    }
+
+    public function appendTo(StreamName $streamName, Iterator $streamEvents): void
+    {
+
+    }
+
+    public function delete(StreamName $streamName): void
+    {
+
+    }
+
+    public function fetchStreamMetadata(StreamName $streamName): array
+    {
+        return [];
+    }
+
+    public function hasStream(StreamName $streamName): bool
+    {
+        return true;
+    }
+
+    public function load(
+        StreamName $streamName,
+        int $fromNumber = 1,
+        int $count = null,
+        MetadataMatcher $metadataMatcher = null
+    ): Iterator {
+        return new \ArrayIterator();
+    }
+
+    public function loadReverse(
+        StreamName $streamName,
+        int $fromNumber = null,
+        int $count = null,
+        MetadataMatcher $metadataMatcher = null
+    ): Iterator {
+        return new \ArrayIterator();
+    }
+
+    /**
+     * @return StreamName[]
+     */
+    public function fetchStreamNames(
+        ?string $filter,
+        ?MetadataMatcher $metadataMatcher,
+        int $limit = 20,
+        int $offset = 0
+    ): array {
+        return [];
+    }
+
+    /**
+     * @return StreamName[]
+     */
+    public function fetchStreamNamesRegex(
+        string $filter,
+        ?MetadataMatcher $metadataMatcher,
+        int $limit = 20,
+        int $offset = 0
+    ): array {
+        return [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function fetchCategoryNames(?string $filter, int $limit = 20, int $offset = 0): array
+    {
+        return [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function fetchCategoryNamesRegex(string $filter, int $limit = 20, int $offset = 0): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
It can be really useful when the `one_stream_per_aggregate` config is set to true. Real event stream table is automatically create on save and for one of my use case I have a different format for aggregate_id (concatenation of 2 uuid separate by `_`) so the column length will become 73 instead of  36. I have my own stream strategy but only for one stream so when I configure my aggregate_repository I need to inject my custom event store